### PR TITLE
Fix: 무한스크롤 debounce 커스텀 훅 적용

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,4 +1,4 @@
-export const BASE_URL = 'http://10.58.52.75:3000';
+export const BASE_URL = 'http://127.0.0.1:3000';
 export const api = {
   productDetail: `${BASE_URL}/products/`,
   login: `${BASE_URL}/users/login`,

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -5,6 +5,7 @@ import CategoryBtn from './components/CategoryBtn';
 import FilterBar from './components/FilterBar';
 import Product from './components/Product';
 import styled from 'styled-components';
+import useDebounce from './Debounce';
 
 function Main() {
   const [mainImage, setMainImage] = useState([]);
@@ -27,6 +28,8 @@ function Main() {
   const sortUrl = `&sort=${optionValue}`;
   const sortOrderUrl = `&sortorder=${sortOrderValue}`;
   const categoryUrl = `&${categoryTitle}=${categoryNum}`;
+
+  const debounceValue = useDebounce(offset);
 
   //Main Image 목데이터 fetch
   useEffect(() => {
@@ -56,29 +59,23 @@ function Main() {
 
   //TODO : 무한 스크롤 fetch
   useEffect(() => {
-    fetch(
-      `http://10.58.52.75:3000/products?${limitOffsetUrl}${sortUrl}${sortOrderUrl}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json;charset=utf-8',
-        },
-      }
-    )
+    fetch(`${api.main}?${limitOffsetUrl}${sortUrl}${sortOrderUrl}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json;charset=utf-8',
+      },
+    })
       .then(response => response.json())
       .then(item => {
         setProducts(prev => prev.concat(item));
       });
 
     window.addEventListener('scroll', handleScroll);
-  }, [offset]);
+  }, [debounceValue]);
 
   const handleScroll = e => {
     const num = e.target.documentElement.scrollTop;
-    if (
-      window.innerHeight + num >=
-      e.target.documentElement.scrollHeight - 200
-    ) {
+    if (window.innerHeight + num >= e.target.documentElement.scrollHeight) {
       setOffset(offset + 10);
     }
   };

--- a/src/pages/Main/components/FilterBar.js
+++ b/src/pages/Main/components/FilterBar.js
@@ -6,9 +6,9 @@ function FilterBar({ setCategoryTitle, setCategoryNum }) {
 
   const categoryClickInfo = (id, urlNum, nameId) => {
     let title;
-    if (id === 1 && id != nameId) {
+    if (id === 1 && id !== nameId) {
       title = 'levelId';
-    } else if (id === 2 && id != nameId) {
+    } else if (id === 2 && id !== nameId) {
       title = 'ageId';
     }
     setCategoryTitle(title);


### PR DESCRIPTION
### 무한스크롤 debounce 커스텀 훅 적용

커스텀 훅을 해당 페이지로 import 해서 변수명에 해당 함수를 저장.
변화하는 offset 값을 debounce 함수의 파라미터로 전달
debounce변수를 무한스크롤 useEffect의 매개변수에 넣어서 변화될 때 debounce가 실행되게 함.

### 구현하면서 생긴 오류

- 1.  fetch 함수의 offset값을 바로 debounce의 변수를 넣음.
        offset 쿼리스트링 뒤에 오는 필터값의 쿼리스트링이 적용이 안됨.
        key값이 중복되는 문제가 생김

- 2. handleScroll 함수의 10씩 더해주는 setOffset 함수에 debounce 적용.
        핸들함수 바깥에 debounce 커스텀 훅이 적용되기 때문에 10개 이상의 값이 안불러와짐